### PR TITLE
Use default init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ stages:
   - publish
 
 before_script:
-  - make init
+  - make
 
 jobs:
   include:


### PR DESCRIPTION
remove the `init` of downloading build-harness