### PR TITLE
set flag to disable build of test docker image that is not needed

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -12,6 +12,9 @@ function fold_end() {
 export DOCKER_IMAGE_AND_TAG=${1}
 export USER_NAME=$(git log -1 --pretty="%aN" | sed 's/[^a-zA-Z0-9]*//g')
 
+# To block build of unnecessary test docker image during make webpack
+export NO_DOCKER=true
+
 fold_start download-clis "DOWNLOADING CLIS"
 make download-clis
 fold_end download-clis


### PR DESCRIPTION
The default OSS KUI make webpack step builds a test docker image that we do not use.  Since this is certainly not needed for a downstream build, removing it in this branch also.