### PR TITLE
Use RH favicon from header

### DIFF
--- a/client/client-default/config.d/icons.json
+++ b/client/client-default/config.d/icons.json
@@ -1,5 +1,5 @@
 {
-  "favicon": "/common-nav/graphics/ICP-favicon.png",
+  "favicon": "/multicloud/header/graphics/RHACM-Favicon.svg",
   "filesystem": {
     "darwin": "icons/icns/kui.icns",
     "win32": "icons/ico/kui.ico",


### PR DESCRIPTION
Issue:  https://github.com/open-cluster-management/backlog/issues/1733

<img width="531" alt="Screen Shot 2020-04-23 at 12 26 24 PM" src="https://user-images.githubusercontent.com/26075187/80124119-c4e4c080-855d-11ea-9d42-6c25068547e5.png">
