### PR TITLE
lock down ubi version, remove nodejs-nodedaemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,9 @@ ENV LINUX_DISTRO rhel
 # ubi8/nodejs-10 base image seems to need this
 USER root
 
-# keep image up-to-date by pulling latest fixes
+# Remove nodejs-nodemon as 1) it is not needed by kui 2) it has package vulnerabilities
+# See: https://github.com/open-cluster-management/backlog/issues/2741
+# Keep image up-to-date 
 RUN yum -y remove nodejs-nodemon && \
     yum -y update
 


### PR DESCRIPTION
Ref: https://github.com/open-cluster-management/backlog/issues/2741