### PR TITLE
Prevent component build colliding with test build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,4 +79,6 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
         - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+        - sleep 60
+        - rm -rf pipeline
         - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
Fix to publish target of `.travis.yml` to prevent component build from colliding with test build.