### PR TITLE
revert change from PR 162 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,6 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
         - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
-        - sleep 60
-        - rm -rf pipeline
-        - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+#       - sleep 60
+#       - rm -rf pipeline
+#       - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
Revert change from https://github.com/open-cluster-management/kui-web-terminal/pull/162 for the `release-2.0` branch.  This is to fix https://github.com/open-cluster-management/backlog/issues/3745