### PR TITLE
3966 scope client and proxy package names

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "client",
+  "name": "@open-cluster-management/kui-web-terminal-client",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "client",
+  "name": "@open-cluster-management/kui-web-terminal-client",
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kui-proxy",
+  "name": "@open-cluster-management/kui-web-terminal-proxy",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kui-proxy",
+  "name": "@open-cluster-management/kui-web-terminal-proxy",
   "version": "1.0.0",
   "description": "Docker image for the Visual Web Terminal proxy to be used in Advanced Cluster Management",
   "main": "node_modules/@kui-shell/core/main/main.js",


### PR DESCRIPTION
Mirroring same change from PR https://github.com/open-cluster-management/kui-web-terminal/pull/168 in the `release-2.1` branch to the `release-2.0` branch for 2.0.3.  

This is part of the work for https://github.com/open-cluster-management/backlog/issues/3966