### PR TITLE
3966 for 2.0.z do not push reference to test image to manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
         - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
-        - sleep 60
-        - rm -rf pipeline
-        - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+# Skip these steps as part of this script until such time as we decide to onboard/enable dockerized tests for release-2.0 branch
+#        - sleep 60
+#        - rm -rf pipeline
+#        - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
These lines had been merged to the `release-2.0` branch from what we enabled in the `release-2.1` branch, but the builds were not using dockerized tests for `kui-web-terminal` image in the 2.0.z builds.  By adding the reference to the manifest, it caused the 2.0.z canary quay retag step to fail.

This is needed to complete the 2.0.3 build changes for https://github.com/open-cluster-management/backlog/issues/3966