### PR TITLE
update oc, kubectl, helm to OCP 4.6 level for 2.1.1

### DIFF
--- a/download-clis.sh
+++ b/download-clis.sh
@@ -21,14 +21,14 @@ mkdir -p ./downloads
 
 if [ "$ARCH" = "amd64" ]; then
   echo "Downloading oc & kubectl ..."
-  curl -fksSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.2/openshift-client-linux-4.5.2.tar.gz | tar -xvz -C ./downloads/ oc kubectl
+  curl -fksSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.3/openshift-client-linux-4.6.3.tar.gz | tar -xvz -C ./downloads/ oc kubectl
   [[ ! -f "downloads/oc" ]] && echo "download oc failed" && exit -1
   mv ./downloads/oc ./downloads/oc-linux-amd64
   [[ ! -f "downloads/kubectl" ]] && echo "download kubectl failed" && exit -1
   mv ./downloads/kubectl ./downloads/kubectl-linux-amd64
   echo "Downloaded openshift origin to downloads/"
 
-  echo "Downloading helm v3..."
+  echo "Downloading helm v3.3.z..."
   curl -fksSL https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o ./downloads/helm-linux-amd64
   [[ ! -f "downloads/helm-linux-amd64" ]] && echo "download helm failed" && exit -1
   echo "Downloaded helm v3 to downloads/"


### PR DESCRIPTION
Change for story https://github.com/open-cluster-management/backlog/issues/6789 for ACM 2.1.1.