### PR TITLE
revert change to RELEASE_FF_BRANCH file

### DIFF
--- a/RELEASE_FF_BRANCH
+++ b/RELEASE_FF_BRANCH
@@ -1,1 +1,1 @@
-release-2.3
+release-2.2


### PR DESCRIPTION
Reverting to trigger a build on the `release-2.2` branch.  The RELEASE_FF_BRANCH file is not used on non-master branch so this will do nothing more than trigger a build when merged.