### PR TITLE
explicitly init session count metric to 0

### DIFF
--- a/proxy/app/lib/metricsUtils.js
+++ b/proxy/app/lib/metricsUtils.js
@@ -13,6 +13,9 @@ const sessionCounter = new promClient.Counter({
     help: 'Count of Visual Web Terminal sessions created on the cluster'
 });
 
+// init sessionCounter to 0
+sessionCounter.inc(0);
+
 module.exports.newSession = function() {
     console.log('Incrementing session count metric for this cluster');
     sessionCounter.inc();


### PR DESCRIPTION
Partial fix for https://github.com/open-cluster-management/backlog/issues/8196