### PR TITLE
update test submodule to latest release-2.1 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "mcm-kui-tests"]
 	path = tests
 	url = git@github.com:open-cluster-management/mcm-kui-tests.git
+	branch = release-2.1


### PR DESCRIPTION
Set `tests` submodule to track the `release-2.1` branch in `mcm-kui-tests` and update the submodule to the latest commit on that branch in `mcm-kui-tests` to fix https://github.com/open-cluster-management/backlog/issues/10866