### PR TITLE
set release-2.2 branch to track 2.2 tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "mcm-kui-tests"]
 	path = tests
 	url = git@github.com:open-cluster-management/mcm-kui-tests.git
+	branch = release-2.2


### PR DESCRIPTION
Set the `release-2.2` branch to track `release-2.2` tests from `mcm-kui-tests`.