### PR TITLE
increase wait between publish of image and test image for 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,6 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
         - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
-        - sleep 60
+        - sleep 300
         - rm -rf pipeline
         - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
Sometimes a one minute wait between publishing the `kui-web-terminal` image and the test image is insufficient and can cause a build to run with old tests.