### PR TITLE
add --nobest flag to yum update in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ USER root
 # See: https://github.com/open-cluster-management/backlog/issues/2741
 # AND Keep image up-to-date
 RUN yum -y remove nodejs-nodemon && \
-    yum -y update
+    yum --nobest -y update
 
 WORKDIR /kui-proxy/kui
 


### PR DESCRIPTION
The `registry.access.redhat.com/ubi8/nodejs-14:1` base image recently started issuing errors on various perl package dependencies when doing `yum -y update` in the Dockerfile.  Recommended solution is to add `--nobest` flag to `yum update`.