### PR TITLE
update deps to fix jsonpath for downstream

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,18 +36,18 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.14.5"
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-      "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
+      "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
       "dev": true
     },
     "@babel/core": {
@@ -88,12 +88,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
-      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+      "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.2",
+        "@babel/types": "^7.14.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -107,13 +107,13 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
-      "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.4",
-        "@babel/helper-validator-option": "^7.12.17",
+        "@babel/compat-data": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
       },
@@ -127,142 +127,151 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
-      "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.14.2"
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
-      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
+      "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
-      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
-      "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-replace-supers": "^7.13.12",
-        "@babel/helper-simple-access": "^7.13.12",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.2",
-        "@babel/types": "^7.14.2"
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5",
+        "@babel/helper-simple-access": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
-      "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.13.12",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.14.2",
-        "@babel/types": "^7.14.4"
+        "@babel/helper-member-expression-to-functions": "^7.14.5",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
-      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
-      "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.5.tgz",
+      "integrity": "sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.14.0"
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.4.tgz",
-      "integrity": "sha512-ArliyUsWDUqEGfWcmzpGUzNfLxTdTp6WU4IuP6QFSp9gGfWS6boxFCkJSJ/L4+RG8z/FnIU3WxCk6hPL9SSWeA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
+      "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
       "dev": true
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -287,48 +296,49 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.5.tgz",
+      "integrity": "sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/traverse": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
-      "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
+      "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.2",
-        "@babel/helper-function-name": "^7.14.2",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.14.2",
-        "@babel/types": "^7.14.2",
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.14.5",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.4.tgz",
-      "integrity": "sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -394,9 +404,9 @@
       "dev": true
     },
     "@kui-shell/builder": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-10.3.17.tgz",
-      "integrity": "sha512-ubaB+mfFcHOmTgopizQ70Gjz274jnBc0fQLUc+GOQS2spSTKONqatSu2taJYEn13sf8v0eS+lSNTqkxPPjCHVQ==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-10.3.20.tgz",
+      "integrity": "sha512-WG4+oNcXi/xRELkRdiaF6rouwXOz197qIQEkUFFCI6v6nZ82Mm+//4IqPKZJENs2bv+tXf1q+IhNvcgsVfdQQQ==",
       "dev": true,
       "requires": {
         "@babel/cli": "7.14.3",
@@ -410,9 +420,9 @@
       "version": "file:client-default"
     },
     "@kui-shell/core": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-10.3.17.tgz",
-      "integrity": "sha512-DquaU/5C1a0ss5K/Mu8OihKNxCLVOe1tQ7kgbK5LTqMDccJlWUCaYTcY/NTEXE39ynSf8Zf3sYzb7xHgoha6oA==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-10.3.20.tgz",
+      "integrity": "sha512-x2nC8q6jIORWeL0QxKX39Y2+BUNMKjymo/zY1pclhuAMk4ouobefKZzd5ZWcIR6yEEt+GVmEKu5uo4vxNN8fXg==",
       "requires": {
         "ansi-to-html": "0.6.15",
         "colors": "1.4.0",
@@ -432,10 +442,20 @@
         "yargs-parser": "20.2.7"
       }
     },
+    "@kui-shell/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kui-shell/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-v6fR7uxUi5KMy7CIyXPiXlS4fOa0YHVLeKb/STvpaPKPkW6D8AzQqeR5u01pR8gkfWXXxkGVrVqTM/Bf9BWLFA==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
     "@kui-shell/plugin-bash-like": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-10.3.17.tgz",
-      "integrity": "sha512-mPY/x2OHVKjwNLRC+YNxEhrVQQWGrs1/fBBHlWKBZBbNnC60JGl8DnqA+G+C85VE0mVvKylJdHVDvonDLoTjmA==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-10.3.20.tgz",
+      "integrity": "sha512-rq05ZR+MEJaJygBm18qQGnLXFOzLfUf1/HmDiUgkFwWKI6O9sWzw5CGOYFwewsX8lGDTDsuiaji08LjHjRZUHQ==",
       "requires": {
         "@kui-shell/xterm-helpers": "1.0.1",
         "@types/cookie": "0.4.0",
@@ -455,19 +475,19 @@
       }
     },
     "@kui-shell/plugin-carbon-themes": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-carbon-themes/-/plugin-carbon-themes-10.3.17.tgz",
-      "integrity": "sha512-Hv9cexVvpWCc15XdQsyY69h8AQt3+q0aAmup7d9Y+Mn9eK5QnhiYI1OcMZHm67cHXgHx2S6u0UZ9fuC/Myj9hw=="
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-carbon-themes/-/plugin-carbon-themes-10.3.20.tgz",
+      "integrity": "sha512-6vThxYlWM6bvMrKRcOg9BaqqpBd9X/qX6osjz90RwKosmH4uOga5IXBYyzXtauvPuaApyA8EMdxRlGcdLTHMJg=="
     },
     "@kui-shell/plugin-client-common": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-10.3.17.tgz",
-      "integrity": "sha512-FlfjIy5RMKPYXeiBianQw4j0ioTGXUZbOHPWmEkoSe6azmSDeWkybXyRpsV5gfb4l5PiDs7k0/zjc1WA2YvuJg==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-10.3.20.tgz",
+      "integrity": "sha512-2OhpQb94yruZb3ikOJXf8ze2eXV8ybI3p+WDH7X84kXPcZb5EsQQ2yX1839+AWly3UXbsvQl7sVDJeyBLj+iIQ==",
       "requires": {
-        "@patternfly/react-charts": "6.14.22",
-        "@patternfly/react-core": "4.121.1",
-        "@patternfly/react-styles": "4.10.7",
-        "@patternfly/react-table": "4.27.7",
+        "@patternfly/react-charts": "6.14.29",
+        "@patternfly/react-core": "4.128.2",
+        "@patternfly/react-styles": "4.10.11",
+        "@patternfly/react-table": "4.27.24",
         "anser": "2.0.1",
         "monaco-editor": "0.24.0",
         "monaco-editor-webpack-plugin": "3.1.0",
@@ -481,9 +501,9 @@
       }
     },
     "@kui-shell/plugin-core-support": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-10.3.17.tgz",
-      "integrity": "sha512-1YYQAeC+9HjrhCmvWUuyXeml5XNjDv3stmnffilGIbqLBGraC464bNEm/n2UO8TOBSmaB85+T5kpoSmOomivcA==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-10.3.20.tgz",
+      "integrity": "sha512-Oe1c7m78nC3Q44rgwIvLmfeLQyHp07N0+aUfWyuuiNl4x2o3pZb73fqwiCRtBFLLA0qqOv+WKw8YSTdWduk4Uw==",
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
         "colors": "1.4.0",
@@ -493,16 +513,16 @@
       }
     },
     "@kui-shell/plugin-kubectl": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-10.3.17.tgz",
-      "integrity": "sha512-eMJ4avhzTThK+XdPIFYD/bPbqoo0RjYwsx//9MEBsPvLw1YMRwFqx7RKbpg0Xyv0AX3FG4YeqfuohKr3t8m7Uw==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-10.3.20.tgz",
+      "integrity": "sha512-lvFLuLCPNYX32mMvy/lcNHPvKWBMFL5UqjYj6cwouGX2F5JHp0WK8eP5GiVKpd7k1kKBm1RXCI6PZg+1o+PfKQ==",
       "requires": {
+        "@kui-shell/jsonpath": "1.1.1",
         "bytes-iec": "3.1.1",
         "command-exists": "1.2.9",
         "debug": "4.3.1",
         "fs-extra": "9.1.0",
-        "js-yaml": "3.14.1",
-        "jsonpath": "github:starpit/jsonpath#preparse",
+        "js-yaml": "4.1.0",
         "needle": "2.6.0",
         "parse-duration": "1.0.0",
         "pluralize": "8.0.0",
@@ -526,14 +546,14 @@
       "integrity": "sha512-HXxM4d1vTH7hY1PAY58C2Cvmt53Zh6s0Ig3O9z37aB9AE7UelMRPhjXdNB1Rny1YYJBCD51hTomyzK/UzRik1Q=="
     },
     "@kui-shell/plugin-patternfly4-themes": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-10.3.17.tgz",
-      "integrity": "sha512-GwYWyUMhHtE9LsokcIn6nzdJJghSlPyEFjWXvCoMctyVNbIQ2yvQF/vNPRJMKyH+PCc/T1XcZ7Lnc1sMyYZuyQ=="
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-10.3.20.tgz",
+      "integrity": "sha512-qVoa+maVZ0b1dnImRCRK0tiK63yJtFr/41Mq+GbKpFg+mJU6tOMJUXH4HbzYbwR+rreNvENwY4gr0NUxgrBDEw=="
     },
     "@kui-shell/plugin-proxy-support": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-10.3.17.tgz",
-      "integrity": "sha512-XeJlqDFvR+cRotBGFD5T43G9v6wr3llKgJADbPL40LHlRrp/IFpNp0evCQHvAKIuoETqsdwbLzZhRA+z3nyQbQ=="
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-10.3.20.tgz",
+      "integrity": "sha512-OGPFhVFEGzGQbrnmJl3lWhDj+BDFmyFxvxvQCzzswEqWKYD2iOm/uZhYlkvI6u4GhrAn7NYPPpADTVn76ZZV1Q=="
     },
     "@kui-shell/plugin-search": {
       "version": "file:../plugin-downloads/plugin-search.tgz",
@@ -550,9 +570,9 @@
       }
     },
     "@kui-shell/react": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-10.3.17.tgz",
-      "integrity": "sha512-3zDdbiHGy0kqKIKm6hy58tfRDi34+NpXBy+70O9hfisAN8pWNZSc1YKxXhZhuxL/iYMWRsx9YhISZqr9ghdn+A==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-10.3.20.tgz",
+      "integrity": "sha512-/yjNgFEB+mD5e9D99N3qy5VOFaIC3R7GiP15cUf02gZ0gERi52hGW6a6mYVqHRT+q8XQgcr3DXSlSicnD2u+rw==",
       "requires": {
         "react": "17.0.2",
         "react-dom": "17.0.2"
@@ -752,12 +772,12 @@
       }
     },
     "@patternfly/react-charts": {
-      "version": "6.14.22",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.14.22.tgz",
-      "integrity": "sha512-9rkokh8JPRryqAPDjP3sB+Kx85v9i2jlMVA0JfAa2rQkhS0gOKgOUkU/I9KegXaDEHvtTpCpI6S6a9uQ9/ewYQ==",
+      "version": "6.14.29",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.14.29.tgz",
+      "integrity": "sha512-bmpfhdhn0gnmZCCIeuGK/N6a6nb2TFWvBv8WZzjQq1lgxW3apeQGnXAEWg/iLEsRHrk19T7hbqoSTmh2t5/HIQ==",
       "requires": {
-        "@patternfly/react-styles": "^4.10.7",
-        "@patternfly/react-tokens": "^4.11.8",
+        "@patternfly/react-styles": "^4.10.11",
+        "@patternfly/react-tokens": "^4.11.12",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.19",
         "tslib": "1.13.0",
@@ -779,13 +799,13 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.121.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.121.1.tgz",
-      "integrity": "sha512-WIlh7Wd4o4r0PA2+9/fPcOxMAnc2H/InPx8rulJzD9a8KdUevl7+XDtKok6p6grKRUriV5wKPQyfZrxcb5VVHw==",
+      "version": "4.128.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.128.2.tgz",
+      "integrity": "sha512-EhrxE3+V7AYVhbERrcRVH7oY6TeVRqqzaRx8HXWnyn/hxE2rTzhhaLHyjotxk9mGYmIYtMuMebBHFbX0g+6Ymg==",
       "requires": {
-        "@patternfly/react-icons": "^4.10.7",
-        "@patternfly/react-styles": "^4.10.7",
-        "@patternfly/react-tokens": "^4.11.8",
+        "@patternfly/react-icons": "^4.10.11",
+        "@patternfly/react-styles": "^4.10.11",
+        "@patternfly/react-tokens": "^4.11.12",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -798,19 +818,19 @@
       "integrity": "sha512-Qyxwvghb9HZB2do3UVw4EzJSvqWaw/AEw6mFzqshZiIm2oPrL4NkvavwDt5WRicz5sbyWTZluB4grOj33PEpww=="
     },
     "@patternfly/react-styles": {
-      "version": "4.10.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.10.7.tgz",
-      "integrity": "sha512-oA9R1dXAJaKhj0/1z/uf2Z1wzsQ4jGQw2F8alPBagbDLyZD+pvUmElBr7o2Ucz/fm+/pLcphekCkGEVtyV3jOA=="
+      "version": "4.10.11",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.10.11.tgz",
+      "integrity": "sha512-M+NhTtAXreJzMAV2Z1P2pbnKpRYnWbB5iZ6mxB0tkxxG+KyZ0/se8M5rUepLOE/n7BMq8IiOjPJ9zu/vpWj0gA=="
     },
     "@patternfly/react-table": {
-      "version": "4.27.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.27.7.tgz",
-      "integrity": "sha512-5lQBkXeBC5qtvum7HWPyd6PxpfO2j/UaIdy8ZeN7X0AVI96p3Zb4hH5WSTla2EAOUEmN0g16Nmxg57ZZREp+kg==",
+      "version": "4.27.24",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.27.24.tgz",
+      "integrity": "sha512-LXKWtCeEJ4KR8ZnyeAPHdDQFJC9KQe/2Z7yJxBHy8gWciLAPcrLvnTtAb+d1O2lFXKMpUKFNUIwzVvuAffjDSA==",
       "requires": {
-        "@patternfly/react-core": "^4.121.1",
-        "@patternfly/react-icons": "^4.10.7",
-        "@patternfly/react-styles": "^4.10.7",
-        "@patternfly/react-tokens": "^4.11.8",
+        "@patternfly/react-core": "^4.128.2",
+        "@patternfly/react-icons": "^4.10.11",
+        "@patternfly/react-styles": "^4.10.11",
+        "@patternfly/react-tokens": "^4.11.12",
         "lodash": "^4.17.19",
         "tslib": "1.13.0"
       }
@@ -973,9 +993,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.9.tgz",
-      "integrity": "sha512-2Cw7FvevpJxQrCb+k5t6GH1KIvmadj5uBbjPaLlJB/nZWUj56e1ZqcD6zsoMFB47MsJUTFl9RJ132A7hb3QFJA==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
+      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -984,9 +1004,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.6.tgz",
-      "integrity": "sha512-MGTI+TudxAnGTj8aco8mogaPSJGK2Whje7OZh1CxNLRyhJpTZg/pGQpIbCT0eCVFQyH7UFpdvCqQEThHIp/gsA==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.7.tgz",
+      "integrity": "sha512-Wd5xvZRlccOrCTej8jZkoFZuZRKHzanDDv1xglI33oBNFMWrqOSzrvWFw7ngSiZjrpJAzPKFtX7JvuXpkNmQHA==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -1434,12 +1454,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -2046,9 +2063,9 @@
       "dev": true
     },
     "cacheable-request": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
       "dev": true,
       "requires": {
         "clone-response": "^1.0.2",
@@ -2056,7 +2073,7 @@
         "http-cache-semantics": "^4.0.0",
         "keyv": "^4.0.0",
         "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
+        "normalize-url": "^6.0.1",
         "responselike": "^2.0.0"
       }
     },
@@ -2095,9 +2112,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001235",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
-      "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
+      "version": "1.0.30001236",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
+      "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
       "dev": true
     },
     "carbon-components": {
@@ -3039,57 +3056,33 @@
       }
     },
     "css-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^3.2.1",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
+        "nth-check": "^2.0.0"
       },
       "dependencies": {
-        "dom-serializer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
           "dev": true,
           "requires": {
-            "domelementtype": "^2.0.1",
-            "entities": "^2.0.0"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-              "dev": true
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-          "dev": true
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
+            "domelementtype": "^2.2.0"
           }
         }
       }
     },
     "css-what": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "dev": true
     },
     "cssesc": {
@@ -3688,9 +3681,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.749",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
-      "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
+      "version": "1.3.752",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
+      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
       "dev": true
     },
     "elliptic": {
@@ -3866,6 +3859,13 @@
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        }
       }
     },
     "eslint-scope": {
@@ -3879,9 +3879,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -5665,12 +5665,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsesc": {
@@ -5728,22 +5727,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      }
-    },
-    "jsonpath": {
-      "version": "github:starpit/jsonpath#2227e607484587be7e6cf22ee5d2dce9b5047bf3",
-      "from": "github:starpit/jsonpath#preparse",
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-        }
       }
     },
     "keyv": {
@@ -6550,9 +6533,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.1.tgz",
+      "integrity": "sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==",
       "dev": true
     },
     "npm-run-path": {
@@ -6576,12 +6559,12 @@
       }
     },
     "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "^1.0.0"
       }
     },
     "number-is-nan": {
@@ -7093,9 +7076,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
-      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.2.tgz",
+      "integrity": "sha512-y1FK/AWdZlBF5lusS5j5l4/vF67+vQZt1SXPVJ32y1kRGDQyrs1zk32hG1cInRTu14P0V+orPz+ifwW/7rR4bg==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
@@ -7689,96 +7672,37 @@
       "dev": true
     },
     "renderkid": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-      "integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
       "dev": true,
       "requires": {
-        "css-select": "^2.0.2",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.10.1",
-        "lodash": "^4.17.20",
-        "strip-ansi": "^3.0.0"
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
-        "dom-serializer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
           "dev": true,
           "requires": {
             "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
             "entities": "^2.0.0"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-              "dev": true
-            },
-            "entities": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-              "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-              "dev": true
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-          "dev": true
-        },
-        "domhandler": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-          "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^1.3.1",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -8571,11 +8495,6 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssri": {
       "version": "6.0.2",
@@ -9485,9 +9404,9 @@
       }
     },
     "victory-brush-container": {
-      "version": "35.8.1",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.8.1.tgz",
-      "integrity": "sha512-vIPbWvxTu2T0z4lLFQI7miNwiutBJJquQR0WW0hewsGktw7Eir2VJ5sLLUyDwBF9T2gvj49HT0jrBwi/j90dsw==",
+      "version": "35.8.5",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.8.5.tgz",
+      "integrity": "sha512-BrwH8GMdsQAENnnnjXRli8rSTMpVdesk84gU5OVuWfjllfcE7XOPJN1YvuvAbU7Dn8wO3IQlaKf9YpOGX0zA3g==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
@@ -9525,12 +9444,12 @@
       }
     },
     "victory-create-container": {
-      "version": "35.8.4",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.8.4.tgz",
-      "integrity": "sha512-HZuVeF3KfAXQBkikKeRFr8Tr5BLEJv2IpNyyUQhTFiSp61Qo9YMzc/ototkQebpwRBaxQqc0h208Fhq6qsDa0A==",
+      "version": "35.8.5",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.8.5.tgz",
+      "integrity": "sha512-GJsIB/T3UbCS7nL+78nhHMnFeMt5a4ixi49BUx+PBLWTqAkrHuY3baoxG5HiNjQPt5XmRWCUqNu3aO/iWjeuCQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^35.8.1",
+        "victory-brush-container": "^35.8.5",
         "victory-core": "^35.8.1",
         "victory-cursor-container": "^35.8.1",
         "victory-selection-container": "^35.8.1",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -36,18 +36,18 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.14.5"
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-      "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
+      "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
       "dev": true
     },
     "@babel/core": {
@@ -88,12 +88,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
-      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+      "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.2",
+        "@babel/types": "^7.14.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -107,13 +107,13 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
-      "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.4",
-        "@babel/helper-validator-option": "^7.12.17",
+        "@babel/compat-data": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
       },
@@ -127,142 +127,151 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
-      "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.14.2"
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
-      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
+      "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
-      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
-      "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-replace-supers": "^7.13.12",
-        "@babel/helper-simple-access": "^7.13.12",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.2",
-        "@babel/types": "^7.14.2"
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5",
+        "@babel/helper-simple-access": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
-      "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.13.12",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.14.2",
-        "@babel/types": "^7.14.4"
+        "@babel/helper-member-expression-to-functions": "^7.14.5",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
-      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
-      "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.5.tgz",
+      "integrity": "sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.14.0"
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.4.tgz",
-      "integrity": "sha512-ArliyUsWDUqEGfWcmzpGUzNfLxTdTp6WU4IuP6QFSp9gGfWS6boxFCkJSJ/L4+RG8z/FnIU3WxCk6hPL9SSWeA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
+      "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
       "dev": true
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -287,46 +296,47 @@
       }
     },
     "@babel/template": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/traverse": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
-      "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
+      "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.2",
-        "@babel/helper-function-name": "^7.14.2",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.14.2",
-        "@babel/types": "^7.14.2",
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.14.5",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.4.tgz",
-      "integrity": "sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@kui-shell/builder": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-10.3.17.tgz",
-      "integrity": "sha512-ubaB+mfFcHOmTgopizQ70Gjz274jnBc0fQLUc+GOQS2spSTKONqatSu2taJYEn13sf8v0eS+lSNTqkxPPjCHVQ==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-10.3.20.tgz",
+      "integrity": "sha512-WG4+oNcXi/xRELkRdiaF6rouwXOz197qIQEkUFFCI6v6nZ82Mm+//4IqPKZJENs2bv+tXf1q+IhNvcgsVfdQQQ==",
       "dev": true,
       "requires": {
         "@babel/cli": "7.14.3",
@@ -340,9 +350,9 @@
       "version": "file:client-default"
     },
     "@kui-shell/core": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-10.3.17.tgz",
-      "integrity": "sha512-DquaU/5C1a0ss5K/Mu8OihKNxCLVOe1tQ7kgbK5LTqMDccJlWUCaYTcY/NTEXE39ynSf8Zf3sYzb7xHgoha6oA==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-10.3.20.tgz",
+      "integrity": "sha512-x2nC8q6jIORWeL0QxKX39Y2+BUNMKjymo/zY1pclhuAMk4ouobefKZzd5ZWcIR6yEEt+GVmEKu5uo4vxNN8fXg==",
       "requires": {
         "ansi-to-html": "0.6.15",
         "colors": "1.4.0",
@@ -377,10 +387,20 @@
         }
       }
     },
+    "@kui-shell/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kui-shell/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-v6fR7uxUi5KMy7CIyXPiXlS4fOa0YHVLeKb/STvpaPKPkW6D8AzQqeR5u01pR8gkfWXXxkGVrVqTM/Bf9BWLFA==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
     "@kui-shell/plugin-bash-like": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-10.3.17.tgz",
-      "integrity": "sha512-mPY/x2OHVKjwNLRC+YNxEhrVQQWGrs1/fBBHlWKBZBbNnC60JGl8DnqA+G+C85VE0mVvKylJdHVDvonDLoTjmA==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-10.3.20.tgz",
+      "integrity": "sha512-rq05ZR+MEJaJygBm18qQGnLXFOzLfUf1/HmDiUgkFwWKI6O9sWzw5CGOYFwewsX8lGDTDsuiaji08LjHjRZUHQ==",
       "requires": {
         "@kui-shell/xterm-helpers": "1.0.1",
         "@types/cookie": "0.4.0",
@@ -415,9 +435,9 @@
       }
     },
     "@kui-shell/plugin-core-support": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-10.3.17.tgz",
-      "integrity": "sha512-1YYQAeC+9HjrhCmvWUuyXeml5XNjDv3stmnffilGIbqLBGraC464bNEm/n2UO8TOBSmaB85+T5kpoSmOomivcA==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-10.3.20.tgz",
+      "integrity": "sha512-Oe1c7m78nC3Q44rgwIvLmfeLQyHp07N0+aUfWyuuiNl4x2o3pZb73fqwiCRtBFLLA0qqOv+WKw8YSTdWduk4Uw==",
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
         "colors": "1.4.0",
@@ -437,16 +457,16 @@
       }
     },
     "@kui-shell/plugin-kubectl": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-10.3.17.tgz",
-      "integrity": "sha512-eMJ4avhzTThK+XdPIFYD/bPbqoo0RjYwsx//9MEBsPvLw1YMRwFqx7RKbpg0Xyv0AX3FG4YeqfuohKr3t8m7Uw==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-10.3.20.tgz",
+      "integrity": "sha512-lvFLuLCPNYX32mMvy/lcNHPvKWBMFL5UqjYj6cwouGX2F5JHp0WK8eP5GiVKpd7k1kKBm1RXCI6PZg+1o+PfKQ==",
       "requires": {
+        "@kui-shell/jsonpath": "1.1.1",
         "bytes-iec": "3.1.1",
         "command-exists": "1.2.9",
         "debug": "4.3.1",
         "fs-extra": "9.1.0",
-        "js-yaml": "3.14.1",
-        "jsonpath": "github:starpit/jsonpath#preparse",
+        "js-yaml": "4.1.0",
         "needle": "2.6.0",
         "parse-duration": "1.0.0",
         "pluralize": "8.0.0",
@@ -483,9 +503,9 @@
       "integrity": "sha512-HXxM4d1vTH7hY1PAY58C2Cvmt53Zh6s0Ig3O9z37aB9AE7UelMRPhjXdNB1Rny1YYJBCD51hTomyzK/UzRik1Q=="
     },
     "@kui-shell/react": {
-      "version": "10.3.17",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-10.3.17.tgz",
-      "integrity": "sha512-3zDdbiHGy0kqKIKm6hy58tfRDi34+NpXBy+70O9hfisAN8pWNZSc1YKxXhZhuxL/iYMWRsx9YhISZqr9ghdn+A==",
+      "version": "10.3.20",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-10.3.20.tgz",
+      "integrity": "sha512-/yjNgFEB+mD5e9D99N3qy5VOFaIC3R7GiP15cUf02gZ0gERi52hGW6a6mYVqHRT+q8XQgcr3DXSlSicnD2u+rw==",
       "requires": {
         "react": "17.0.2",
         "react-dom": "17.0.2"
@@ -941,12 +961,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -1342,9 +1359,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
-      "version": "1.0.30001235",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
-      "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
+      "version": "1.0.30001236",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
+      "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
       "dev": true
     },
     "caseless": {
@@ -1838,9 +1855,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.749",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
-      "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
+      "version": "1.3.752",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
+      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
       "dev": true
     },
     "emoji-regex": {
@@ -1938,6 +1955,13 @@
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        }
       }
     },
     "eslint": {
@@ -1991,6 +2015,21 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -2005,6 +2044,16 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "mkdirp": {
           "version": "0.5.5",
@@ -2172,9 +2221,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
     },
     "esquery": {
       "version": "1.4.0",
@@ -3481,12 +3530,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -3590,22 +3638,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      }
-    },
-    "jsonpath": {
-      "version": "github:starpit/jsonpath#2227e607484587be7e6cf22ee5d2dce9b5047bf3",
-      "from": "github:starpit/jsonpath#preparse",
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-        }
       }
     },
     "jsprim": {
@@ -5195,7 +5227,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",


### PR DESCRIPTION
Fix client and proxy dependencies to pick up KUI v10.3.20 to fix dependency for `jsonpath` that did not previously work for downstream builds.  Merge changes for https://github.com/open-cluster-management/backlog/issues/12072 yesterday did not successfully build downstream even though upstream built fine.