### PR TITLE
increase wait time between two publishes to pipeline manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,6 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
         - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
-        - sleep 60
+        - sleep 900
         - rm -rf pipeline
         - make pipeline-manifest/update COMPONENT_NAME=kui-web-terminal-tests PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
When merging a PR and publishing the updated image and test image to the CICD pipeline-manifest, the publish of the test image did not wait long enough until the publish of the kui-web-terminal image completed.